### PR TITLE
fix: invalid recent year dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🇿🇦 south-african-id-validator 🇿🇦
 
-Dead simple validator for South African ID numbers
+Dead simple validator for South African ID numbers. Takes eligibility age into account (16 years).
 
 This validator returns the following if the ID Number is valid
 
@@ -21,14 +21,22 @@ yarn add south-african-id-validator
 ```
 
 ```js
-import { validateIdNumber } from "south-african-id-validator";
+import { parseDOB, parseCitizenship, parseGender, validateIdNumber } from "south-african-id-validator";
 
+// all functions take ID number string as input eg:
 validateIdNumber(
   ID_NUMBER_TO_VALIDATE // string
 );
 
-// example
-validateIdNumber("7311190013080");
+// examples
+console.log(parseDOB('7311190013080'));
+// Date -> Mon Nov 19 1973 00:00:00 GMT+0200 (South Africa Standard Time)
+console.log(parseCitizenship('7311190013080'));
+// true
+console.log(parseGender('7311190013080'));
+// "female"
+console.log(validateIdNumber('7311190013080'));
+// { DOB: Mon Nov 19 1973 00:00:00 GMT+0200 (South Africa Standard Time), gender: "female", isCitizen: true, valid: true }
 ```
 
 ### Demo

--- a/index.js
+++ b/index.js
@@ -55,16 +55,23 @@ export const parseDOB = idNumber => {
   // get year, and assume the century
   const currentYear = new Date().getFullYear();
   const currentCentury = Math.floor(currentYear / 100) * 100;
+  const currentMonth = new Date().getMonth();
+  const currentDay = new Date().getDay();
+  
   let yearPart = currentCentury + parseInt(idNumber.substring(0, 2), 10);
-  if (yearPart > currentYear) {
-    yearPart -= 100; // must be last century
-  }
 
   // In Javascript, Jan=0. In ID Numbers, Jan=1.
   const monthPart = parseInt(idNumber.substring(2, 4), 10) - 1;
 
   const dayPart = parseInt(idNumber.substring(4, 6), 10);
 
+  // only 16 years and above are eligible for an ID
+  const eligibleYear = currentYear - 16;
+  // make sure the ID's DOB is not below 16 years from today, if so it's last century issue
+  if (yearPart > eligibleYear || yearPart === eligibleYear && (monthPart > currentMonth || monthPart === currentMonth && dayPart > currentDay)) {
+    yearPart -= 100; // must be last century
+  }
+  
   const dateOfBirth = new Date(yearPart, monthPart, dayPart);
 
   // validate that date is in a valid range by making sure that it wasn't 'corrected' during construction


### PR DESCRIPTION
only 16 years and above are eligible for an ID therefore anyone born 16 years and below is considered last century issue, they couldn't have applied for an ID. However, this doesn't eliminate issues with the actual underlying problem here, the ID number doesn't keep the full year. Anyone older than 116 years will mistake them to be born around this century and be 116 years younger.